### PR TITLE
Feat: map Linear usernames and GitHub usernames

### DIFF
--- a/pages/api/utils.ts
+++ b/pages/api/utils.ts
@@ -1,0 +1,136 @@
+import { LinearClient } from "@linear/sdk";
+import petitio from "petitio";
+import prisma from "../../prisma";
+
+/**
+ * Server-only utility functions
+ */
+
+/**
+ * Map a Linear username to a GitHub username in the database if not already mapped
+ *
+ * @param {LinearClient} linearClient to get the authenticated Linear user's info
+ * @param {number} githubUserId
+ * @param {string} linearUserId
+ * @param {string} userAgentHeader to respect GitHub API's policies
+ * @param {string} githubAuthHeader to get the authenticated GitHub user's info
+ */
+export const upsertUser = async (
+    linearClient: LinearClient,
+    githubUserId: number,
+    linearUserId: string,
+    userAgentHeader: string,
+    githubAuthHeader: string
+): Promise<void> => {
+    const existingUser = await prisma.user.findFirst({
+        where: {
+            AND: {
+                githubUserId: githubUserId,
+                linearUserId: linearUserId
+            }
+        }
+    });
+
+    if (!existingUser) {
+        console.log("Adding user to users table");
+
+        const linearUser = await linearClient.viewer;
+
+        const githubUser = await petitio(`https://api.github.com/user`, "GET")
+            .header("User-Agent", userAgentHeader)
+            .header("Authorization", githubAuthHeader)
+            .send();
+        const githubUserBody = await githubUser.json();
+
+        await prisma.user.upsert({
+            where: {
+                githubUserId_linearUserId: {
+                    githubUserId: githubUserId,
+                    linearUserId: linearUserId
+                }
+            },
+            update: {
+                githubUsername: githubUserBody.login,
+                githubEmail: githubUserBody.email ?? "",
+                linearUsername: linearUser.displayName,
+                linearEmail: linearUser.email ?? ""
+            },
+            create: {
+                githubUserId: githubUserId,
+                linearUserId: linearUserId,
+                githubUsername: githubUserBody.login,
+                githubEmail: githubUserBody.email ?? "",
+                linearUsername: linearUser.displayName,
+                linearEmail: linearUser.email ?? ""
+            }
+        });
+    }
+
+    return;
+};
+
+/**
+ * Translate users' usernames from one platform to the other
+ * @param {string[]} usernames of Linear or GitHub users
+ * @returns {string[]} Linear and GitHub usernames corresponding to the provided usernames
+ */
+export const mapUsernames = async (
+    usernames: string[],
+    platform: "linear" | "github"
+): Promise<Array<{ githubUsername: string; linearUsername: string }>> => {
+    console.log(`Mapping ${platform} usernames`);
+
+    const filters = usernames.map((username: string) => {
+        return { [`${platform}Username`]: username };
+    });
+
+    const existingUsers = await prisma.user.findMany({
+        where: {
+            OR: filters
+        },
+        select: {
+            githubUsername: true,
+            linearUsername: true
+        }
+    });
+
+    if (!existingUsers?.length) return [];
+
+    return existingUsers;
+};
+
+/**
+ * Replace all mentions of users with their username in the corresponding platform
+ * @param {string} body the message to be sent
+ * @returns {string} the message with all mentions replaced
+ */
+export const replaceMentions = async (
+    body: string,
+    platform: "linear" | "github"
+) => {
+    if (!body?.match(/(?<=@)\w+/g)) return body;
+
+    console.log(`Replacing ${platform} mentions`);
+
+    let sanitizedBody = body;
+
+    const mentionMatches = sanitizedBody.matchAll(/(?<=@)\w+/g) ?? [];
+    const userMentions =
+        Array.from(mentionMatches)?.map(mention => mention?.[0]) ?? [];
+
+    const userMentionReplacements = await mapUsernames(userMentions, platform);
+
+    userMentionReplacements.forEach(mention => {
+        sanitizedBody = sanitizedBody.replace(
+            new RegExp(`@${mention[`${platform}Username`]}`, "g"),
+            `@${
+                mention[
+                    `${platform === "linear" ? "github" : "linear"}Username`
+                ]
+            }`
+        );
+    });
+
+    return sanitizedBody;
+};
+

--- a/prisma/migrations/20221026185709_add_users_table/migration.sql
+++ b/prisma/migrations/20221026185709_add_users_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "users" (
+    "id" TEXT NOT NULL,
+    "githubUserId" INTEGER NOT NULL,
+    "githubUsername" TEXT NOT NULL,
+    "githubEmail" TEXT,
+    "linearUserId" TEXT NOT NULL,
+    "linearUsername" TEXT NOT NULL,
+    "linearEmail" TEXT,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_githubUserId_linearUserId_key" ON "users"("githubUserId", "linearUserId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,3 +78,18 @@ model Sync {
     @@unique([githubUserId, linearUserId, githubRepoId, linearTeamId])
     @@map("syncs")
 }
+
+model User {
+    id String @id @default(cuid())
+
+    githubUserId   Int
+    githubUsername String
+    githubEmail    String?
+
+    linearUserId   String
+    linearUsername String
+    linearEmail    String?
+
+    @@unique([githubUserId, linearUserId])
+    @@map("users")
+}


### PR DESCRIPTION
# Summary

- Mention a Linear @user and their GitHub @username will be mentioned in the corresponding comment or description
- Forward-compatible only: a user's usernames will be stored the next time they create an issue or comment. This is because the Linear:GitHub mapping is not public, and thus non-synced usernames will not change.

### TODO
- Linear does not seem to parse @usernames in comments from the API. Looking for a workaround.

![image](https://user-images.githubusercontent.com/36117635/198144653-42311a7b-a4f0-4b0e-94de-08d68d4e41b4.png)


Closes #18 
Contributes to #12