### PR TITLE
[WIP] Sync assignee

### DIFF
--- a/utils/errors.ts
+++ b/utils/errors.ts
@@ -1,7 +1,7 @@
 import { formatJSON } from ".";
 
 export const getIssueUpdateError = (
-    resource: "state" | "description" | "title",
+    resource: "state" | "description" | "title" | "assignee",
     data: { number: number; id: string; team: { key: string } },
     syncedIssue: { githubIssueNumber: number; githubIssueId: number },
     updatedIssueResponse: { statusCode: number; json: () => any }

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -107,7 +107,7 @@ export const isIssue = (req: NextApiRequest): boolean => {
 };
 
 export const skipReason = (
-    event: "issue" | "edit" | "comment" | "state change" | "label",
+    event: "issue" | "edit" | "comment" | "state change" | "label" | "assignee",
     issueNumber: number | string,
     causedBySync: boolean = false
 ): string => {


### PR DESCRIPTION
# Summary

- When a Linear member is assigned to a synced ticket, the corresponding GH user is assigned to the issue if available
- Same for un-assignment

TODO
- [ ] Sync GitHub assignee > Linear assignee
- [ ] Sync assignees during ticket creation

## Test Plan

- Loom to come

## Related Issues

Closes #12 

