### PR TITLE
Fix sync matching for multi team setup

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -78,7 +78,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         }
 
         const sync = syncs.find(
-            sync => sync.linearUserId === (data.userId ?? data.creatorId)
+            sync => sync.linearUserId === (data.userId ?? data.creatorId) && sync.linearTeamId === data.teamId
         );
 
         if (!sync?.LinearTeam || !sync?.GitHubRepo) {

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -67,7 +67,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         if (
             syncs.length === 0 ||
             !syncs.find(
-                sync => sync.linearUserId === (data.userId ?? data.creatorId)
+                sync => sync.linearUserId === (data.userId ?? data.creatorId) && sync.linearTeamId === data.teamId
             )
         ) {
             console.log("Could not find Linear user in syncs.");

--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -64,22 +64,22 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
             }
         });
 
-        if (
-            syncs.length === 0 ||
-            !syncs.find(
-                sync => sync.linearUserId === (data.userId ?? data.creatorId) && sync.linearTeamId === data.teamId
-            )
-        ) {
+        const sync = syncs.find((sync) => {
+            // For comment events the teamId property from linear is not passed,
+            // so we fallback to only match on user
+            const isTeamMatching = data.teamId ? sync.linearTeamId === data.teamId : true;
+            const isUserMatching = sync.linearUserId === (data.userId ?? data.creatorId);
+
+            return isUserMatching && isTeamMatching;
+        });
+
+        if (syncs.length === 0 || !sync) {
             console.log("Could not find Linear user in syncs.");
             return res.status(200).send({
                 success: true,
                 message: "Could not find Linear user in syncs."
             });
         }
-
-        const sync = syncs.find(
-            sync => sync.linearUserId === (data.userId ?? data.creatorId) && sync.linearTeamId === data.teamId
-        );
 
         if (!sync?.LinearTeam || !sync?.GitHubRepo) {
             console.log("Could not find ticket's corresponding repo.");


### PR DESCRIPTION
# Summary

When filtering sync, add a `linearTeamId` as part of the comparison to allow same user to be part of multiple linear teams. Internally we would love to sync issues from a `Roadmap` team to another repository at https://github.com/novuhq/roadmap, currently issues are not synced in this setup (we already sync issues for our main repo `novuhq/novu`

## Reproduce

- Create 2 linear teams
- Assign a user to be part of both teams
- Try to sync issues from both teams
- Only issues created from the first team will be synced



