### PR TITLE
Use oauth as env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,5 @@ GITHUB_API_KEY="gho_abc123"
 # These are only necessary for self-hosting (team use)
 LINEAR_OAUTH_SECRET="abc123"
 GITHUB_OAUTH_SECRET="abc123"
+NEXT_PUBLIC_GITHUB_OAUTH_ID=""
+NEXT_PUBLIC_LINEAR_OAUTH_ID=""

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,7 +1,7 @@
 import colors from "tailwindcss/colors";
 
 export const LINEAR = {
-    OAUTH_ID: "de24196afa78e6f3f99875b753a3ae29",
+    OAUTH_ID: process.env.NEXT_PUBLIC_LINEAR_OAUTH_ID,
     OAUTH_URL: "https://linear.app/oauth/authorize",
     TOKEN_URL: "https://api.linear.app/oauth/token",
     SCOPES: ["write"],
@@ -25,7 +25,7 @@ export const SHARED = {
 };
 
 export const GITHUB = {
-    OAUTH_ID: "487937ed57e1d5ffea0d",
+    OAUTH_ID: process.env.NEXT_PUBLIC_GITHUB_OAUTH_ID,
     OAUTH_URL: "https://github.com/login/oauth/authorize",
     TOKEN_URL: "https://github.com/login/oauth/access_token",
     SCOPES: ["repo", "write:repo_hook", "read:user", "user:email"],
@@ -103,4 +103,3 @@ export const GENERAL = {
         }
     ]
 };
-


### PR DESCRIPTION
# Summary

Instead of writing hard coded ouath id's use next js public environment variables that will be bundled on the client side aswell.

synclinear deployment should probably inject them in their own deployment of synclinear.com

## Related Issues

This happened accidentally in my previous PR and potentially can happen to other people.

