### PR TITLE
Don't throw http errors to for error validation in code

### DIFF
--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -184,7 +184,8 @@ export async function linearWebhookHandler(
                         headers: {
                             Authorization: githubAuthHeader,
                             "User-Agent": userAgentHeader
-                        }
+                        },
+                        throwHttpErrors: false
                     }
                 );
 
@@ -358,7 +359,8 @@ export async function linearWebhookHandler(
                         headers: {
                             Authorization: githubAuthHeader,
                             "User-Agent": userAgentHeader
-                        }
+                        },
+                        throwHttpErrors: false
                     }
                 );
 
@@ -395,7 +397,8 @@ export async function linearWebhookHandler(
                         headers: {
                             Authorization: githubAuthHeader,
                             "User-Agent": userAgentHeader
-                        }
+                        },
+                        throwHttpErrors: false
                     }
                 );
 
@@ -761,7 +764,8 @@ export async function linearWebhookHandler(
                     headers: {
                         Authorization: githubAuthHeader,
                         "User-Agent": userAgentHeader
-                    }
+                    },
+                    throwHttpErrors: false
                 }
             );
 
@@ -1000,7 +1004,8 @@ export async function linearWebhookHandler(
                         headers: {
                             Authorization: githubAuthHeader,
                             "User-Agent": userAgentHeader
-                        }
+                        },
+                        throwHttpErrors: false
                     }
                 );
 
@@ -1038,7 +1043,8 @@ export async function linearWebhookHandler(
                         headers: {
                             Authorization: githubAuthHeader,
                             "User-Agent": userAgentHeader
-                        }
+                        },
+                        throwHttpErrors: false
                     }
                 );
 


### PR DESCRIPTION
# Summary

Instead of throwing http errors, `got` configured to just respond with the object. This is used when validating the response for existing labels on GitHub.

## Test Plan

- New labels from linear to GH
- Existing labels from linear to GH

