### PR TITLE
Fix/milestone parsing

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -122,3 +122,6 @@ export const skipReason = (
     }.`;
 };
 
+export const isNumber = (value: string | number): boolean => {
+    return !isNaN(Number(value));
+};

--- a/utils/linear.ts
+++ b/utils/linear.ts
@@ -167,6 +167,31 @@ export const createLinearPublicLabel = async (
     return await linearQuery(mutation, token, { teamID });
 };
 
+export const getLinearCycle = async (
+    token: string,
+    cycleId: string
+): Promise<{
+    data: {
+        cycle: {
+            name: string;
+            description: string;
+            number: number;
+            endsAt: string;
+        };
+    };
+}> => {
+    const query = `query GetCycle($cycleId: String!) {
+        cycle(id: $cycleId) {
+            name
+            description
+            number
+            endsAt
+        }
+    }`;
+
+    return await linearQuery(query, token, { cycleId });
+};
+
 export const createLinearCycle = async (
     token: string,
     teamId: string,
@@ -325,3 +350,4 @@ export const inviteMember = async (
 export const generateLinearUUID = (): string => {
     return `${uuid().substring(0, 28)}${GITHUB.UUID_SUFFIX}`;
 };
+

--- a/utils/webhook/github.handler.ts
+++ b/utils/webhook/github.handler.ts
@@ -551,12 +551,6 @@ export async function githubWebhookHandler(
             }
         }
 
-        if (milestone.description?.includes(getSyncFooter())) {
-            const reason = `Skipping over milestone "${milestone.title}" because it is caused by sync`;
-            console.log(reason);
-            return reason;
-        }
-
         let syncedMilestone = await prisma.milestone.findFirst({
             where: {
                 milestoneId: milestone.number,
@@ -565,6 +559,12 @@ export async function githubWebhookHandler(
         });
 
         if (!syncedMilestone) {
+            if (milestone.description?.includes(getSyncFooter())) {
+                const reason = `Skipping over milestone "${milestone.title}" because it is caused by sync`;
+                console.log(reason);
+                return reason;
+            }
+
             const createdCycle = await createLinearCycle(
                 linearKey,
                 linearTeamId,

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -636,9 +636,9 @@ export async function linearWebhookHandler(
                 }
 
                 const title = !cycle.name
-                    ? `v${cycle.number}`
+                    ? `v.${cycle.number}`
                     : isNumber(cycle.name)
-                    ? `v${cycle.name}`
+                    ? `v.${cycle.name}`
                     : cycle.name;
                 const today = new Date();
                 const state: MilestoneState =

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -620,9 +620,8 @@ export async function linearWebhookHandler(
                 // Create milestone, considered "closed" if cycle has ended
                 const today = new Date();
                 const state: MilestoneState =
-                    cycle.startsAt < today && cycle.endsAt > today
-                        ? "open"
-                        : "closed";
+                    new Date(cycle.endsAt) > today ? "open" : "closed";
+
                 const createdMilestone = await createMilestone(
                     githubKey,
                     syncedIssue.GitHubRepo.repoName,

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -6,6 +6,7 @@ import {
     formatJSON,
     getAttachmentQuery,
     getSyncFooter,
+    isNumber,
     skipReason
 } from "../index";
 import { LinearClient } from "@linear/sdk";
@@ -634,6 +635,11 @@ export async function linearWebhookHandler(
                     return reason;
                 }
 
+                const title = !cycle.name
+                    ? `v${cycle.number}`
+                    : isNumber(cycle.name)
+                    ? `v${cycle.name}`
+                    : cycle.name;
                 const today = new Date();
                 const state: MilestoneState =
                     new Date(cycle.endsAt) > today ? "open" : "closed";
@@ -641,7 +647,7 @@ export async function linearWebhookHandler(
                 const createdMilestone = await createMilestone(
                     githubKey,
                     syncedIssue.GitHubRepo.repoName,
-                    cycle.name || `Cycle ${cycle.number}`,
+                    title,
                     `${cycle.description}\n\n> ${getSyncFooter()}`,
                     state
                 );


### PR DESCRIPTION
# Summary

- Fix blocked milestone syncs by properly scoping check for `"from SyncLinear"` signature
- Sync cycle descriptions to milestones
- Ensure milestones are `open` unless the cycle has ended
- Name numbered milestones as `"vN.N"`

## Test Plan

- Add a synced Linear ticket to a new cycle. Ensure a milestone is made and added to the synced issue.
- Repeat in other direction
- Repeat with a cycle named "1.2". Ensure the milestone is named "v1.2".

## Related Issues

Closes #56 

