### PR TITLE
Sync estimates to labels

### DIFF
--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -924,7 +924,8 @@ export async function linearWebhookHandler(
                     headers: {
                         Authorization: githubAuthHeader,
                         "User-Agent": userAgentHeader
-                    }
+                    },
+                    throwHttpErrors: false
                 }
             );
 

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -916,7 +916,7 @@ export async function linearWebhookHandler(
 
         if ("estimate" in updatedFrom) {
             // Remove old estimate label
-            const prevLabelName = `${data["estimate"]} points`;
+            const prevLabelName = `${updatedFrom["estimate"]} points`;
 
             const removedLabelResponse = await got.delete(
                 `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}/labels/${prevLabelName}`,
@@ -939,7 +939,7 @@ export async function linearWebhookHandler(
                 );
             }
 
-            if (data["estimate"] === null) {
+            if (!data["estimate"]) {
                 return `Removed estimate label "${prevLabelName}" from issue #${syncedIssue.githubIssueNumber}.`;
             }
 

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -913,6 +913,93 @@ export async function linearWebhookHandler(
                 );
             }
         }
+
+        if ("estimate" in updatedFrom) {
+            // Remove old estimate label
+            const prevLabelName = `${data["estimate"]} points`;
+
+            const removedLabelResponse = await got.delete(
+                `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}/labels/${prevLabelName}`,
+                {
+                    headers: {
+                        Authorization: githubAuthHeader,
+                        "User-Agent": userAgentHeader
+                    }
+                }
+            );
+
+            if (removedLabelResponse.statusCode > 201) {
+                console.log(
+                    `Did not remove estimate label "${prevLabelName}".`
+                );
+            } else {
+                console.log(
+                    `Removed estimate "${prevLabelName}" from issue #${syncedIssue.githubIssueNumber}.`
+                );
+            }
+
+            if (data["estimate"] === null) {
+                return `Removed estimate label "${prevLabelName}" from issue #${syncedIssue.githubIssueNumber}.`;
+            }
+
+            // Create new estimate label if not yet existent
+            const estimateLabel = {
+                name: `${data["estimate"]} points`,
+                color: "666"
+            };
+
+            const createdLabelResponse = await got.post(
+                `https://api.github.com/repos/${repoFullName}/labels`,
+                {
+                    json: {
+                        name: estimateLabel.name,
+                        color: estimateLabel.color,
+                        description: "Created by SyncLinear.com"
+                    },
+                    headers: {
+                        Authorization: githubAuthHeader,
+                        "User-Agent": userAgentHeader
+                    },
+                    throwHttpErrors: false
+                }
+            );
+
+            const createdLabelData = JSON.parse(createdLabelResponse.body);
+
+            const labelExists =
+                createdLabelData.errors?.[0]?.code === "already_exists";
+
+            if (createdLabelResponse.statusCode > 201 && !labelExists) {
+                console.log("Could not create estimate label.");
+                throw new ApiError("Could not create estimate label.", 403);
+            }
+
+            const labelName = labelExists
+                ? estimateLabel.name
+                : createdLabelData.name;
+
+            const appliedLabelResponse = await got.post(
+                `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}/labels`,
+                {
+                    json: {
+                        labels: [labelName]
+                    },
+                    headers: {
+                        Authorization: githubAuthHeader,
+                        "User-Agent": userAgentHeader
+                    }
+                }
+            );
+
+            if (appliedLabelResponse.statusCode > 201) {
+                console.log("Could not apply label.");
+                throw new ApiError("Could not apply label.", 403);
+            } else {
+                console.log(
+                    `Applied estimate label "${labelName}" to issue #${syncedIssue.githubIssueNumber}.`
+                );
+            }
+        }
     } else if (action === "create") {
         if (actionType === "Comment") {
             // Comment added


### PR DESCRIPTION
# Summary

- When a Linear ticket is given an estimate (eg. `3 Points`, `XL`, `21 Points`), apply a label to the synced GitHub issue
- Under the hood, the "t-shirt sizes" estimates are modelled by Linear as Fibonacci numbers (eg. L, XL, XXL are 5, 8, 13, etc), allowing all labels to be written as `X points`
<img src="https://user-images.githubusercontent.com/36117635/221029024-97f8ca92-522e-4351-a8d7-a56a942f7201.png" width="500" />

<img src="https://user-images.githubusercontent.com/36117635/221029224-bcb5f6ff-85e2-4f5b-b799-15526762c470.png" width="400" />

## Test Plan

✅ Add an estimate to an unestimated, synced Linear ticket. Ensure the synced GH issue gets labelled.
✅ Remove the estimate. Ensure the label gets removed (alternatively, we could label these as `No estimate`?).
✅ In Linear Settings > Teams > General > Estimates > Issue estimation, change the estimate scheme. Update an estimate. Ensure the label updates as expected.

## Related Issues

n/a - discussed in Slack

