### PR TITLE
Log healthcheck errors

### DIFF
--- a/pages/api/health-check.ts
+++ b/pages/api/health-check.ts
@@ -15,6 +15,7 @@ export default async function handle(_, res: NextApiResponse) {
         await prisma.$connect();
         return res.status(200).send("Successfully connected to the database!");
     } catch (e) {
+        console.error(e);
         return res
             .status(503)
             .send(


### PR DESCRIPTION
# Summary

Errors thrown in the healthchecker are currently silently ignored. This means that there's no real way to know _why_ the app wasn't able to connect to the database. This PR resolves that by logging the error to the (server) console.

## Test Plan

n/a

## Related Issues

n/a

