### PR TITLE
Fix originIP extraction

### DIFF
--- a/pages/api/index.ts
+++ b/pages/api/index.ts
@@ -15,10 +15,17 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
          * Linear webhook consumer
          */
         if (req.headers["user-agent"] === "Linear-Webhook") {
-            const result = await linearWebhookHandler(
-                req.body,
-                req.headers["x-forwarded-for"] as string
-            );
+            let originIp = req.headers["x-forwarded-for"];
+
+            if (Array.isArray(originIp)) {
+                originIp = originIp[0];
+            }
+
+            if (originIp.includes(",")) {
+                originIp = originIp.split(",")[0].trim();
+            }
+
+            const result = await linearWebhookHandler(req.body, originIp);
 
             if (result) {
                 return res.status(200).send({


### PR DESCRIPTION
In the webhook handler, `originIp` is extracted by using the raw value from the `x-forwarded-for` header. In some CDNs like Cloudflare, (which is what you get by default on DigitalOcean App Platform), the `x-forwarded-for` header includes both the origin and CDN IP addresses. As it currently stands, the webhook handler is broken, as the full "IP" (f.e. ` 35.243.134.228,172.71.22.154`) isn't a known IP address for Linear