### PR TITLE
Update webhook secret when deploying a new webhook for GitHub

### DIFF
--- a/pages/api/github/save.ts
+++ b/pages/api/github/save.ts
@@ -18,7 +18,7 @@ export default async function handle(
     try {
         const result = await prisma.gitHubRepo.upsert({
             where: { repoId: repoId },
-            update: { repoName },
+            update: { repoName, webhookSecret },
             create: {
                 repoId,
                 repoName,


### PR DESCRIPTION
# Summary

What have you changed? Provide context for those unfamiliar with what you're working on!
When deleting and redeploying a new webhook, the old webhook secret is not updated. I looked at the code and it seems like it only updates repository name. When redeploying a webhook, the secret will change and therefore should also be updated in the upsert.

```
{"success":false,"message":"GitHub webhook secret doesn't match up."}
```

## Test Plan

I haven't tested this locally, but I do believe this should work

## Related Issues

Perhaps this PR will solve #82


