### PR TITLE
fix: remove horizontal overflow

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,7 +3,7 @@ import GitHubLogo from "./icons/GitHubLogo";
 
 const Footer = () => {
     return (
-        <footer className="w-screen p-6 text-lg font-light text-gray-200">
+        <footer className="w-full p-6 text-lg font-light text-gray-200">
             <div className="p-20 flex flex-col sm:flex-row items-center justify-between gap-4 bg-gray-900 rounded-3xl">
                 <div className="space-x-1 text-center">
                     <span>An open-source project by</span>
@@ -42,4 +42,3 @@ const Footer = () => {
 };
 
 export default Footer;
-

--- a/components/Landing.tsx
+++ b/components/Landing.tsx
@@ -11,7 +11,7 @@ import Tooltip from "./Tooltip";
 
 const Landing = () => {
     return (
-        <section className="w-screen min-h-screen center gap-40 py-40 px-6">
+        <section className="w-full min-h-screen center gap-40 py-40 px-6">
             <div className="mx-6 p-6 sm:p-12 w-full rounded-3xl bg-gray-900 center">
                 <div className="space-y-10 max-w-xl text-center">
                     <h2 className="text-gray-200">What does it do?</h2>
@@ -147,4 +147,3 @@ const Landing = () => {
 };
 
 export default Landing;
-

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -82,7 +82,7 @@ const index = () => {
         <div>
             <PageHead />
             <Header />
-            <section className="w-screen min-h-[80vh] center gap-24 px-6">
+            <section className="w-full min-h-[80vh] center gap-24 px-6">
                 <div className="space-y-4 text-center pt-8">
                     <span className="px-3 py-1 rounded-full bg-gray-500 text-gray-200">
                         Beta
@@ -155,4 +155,3 @@ const index = () => {
 };
 
 export default index;
-


### PR DESCRIPTION
# Summary

I replaced `w-screen` by `w-full` to avoid horizontal overflow.

![image](https://github.com/calcom/synclinear.com/assets/69633530/b039554b-4623-43e2-99ee-fa06ec4e30ca)

## Test Plan

Tested by running the website locally.

## Related Issues

None.

