### PR TITLE
Add exit conditions to assignee sync

### DIFF
--- a/utils/webhook/github.handler.ts
+++ b/utils/webhook/github.handler.ts
@@ -13,7 +13,9 @@ import { replaceMentions, upsertUser } from "../../pages/api/utils";
 import {
     Issue,
     IssueCommentCreatedEvent,
+    IssuesAssignedEvent,
     IssuesEvent,
+    IssuesUnassignedEvent,
     MilestoneEvent,
     Repository,
     User
@@ -483,61 +485,71 @@ export async function githubWebhookHandler(
             return reason;
         }
 
-        const { assignee } = issue;
+        const { assignee: modifiedAssignee } = body as
+            | IssuesAssignedEvent
+            | IssuesUnassignedEvent;
+
+        const ticket = await linear.issue(syncedIssue.linearIssueId);
+        const linearAssignee = await ticket?.assignee;
+
+        const remainingAssignee = issue?.assignee?.id
+            ? await prisma.user.findFirst({
+                  where: { githubUserId: issue?.assignee?.id },
+                  select: { linearUserId: true }
+              })
+            : null;
 
         if (action === "unassigned") {
             // Remove assignee
 
-            const remainingAssignee = assignee?.id
-                ? await prisma.user.findFirst({
-                      where: { githubUserId: assignee?.id },
-                      select: { linearUserId: true }
-                  })
-                : null;
+            // Set remaining assignee only if different from current
+            if (linearAssignee?.id != remainingAssignee?.linearUserId) {
+                const response = await linear.issueUpdate(
+                    syncedIssue.linearIssueId,
+                    { assigneeId: remainingAssignee?.linearUserId || null }
+                );
 
-            const response = await linear.issueUpdate(
-                syncedIssue.linearIssueId,
-                { assigneeId: remainingAssignee?.linearUserId || null }
-            );
-
-            if (!response?.success) {
-                const reason = `Failed to remove assignee on Linear ticket for GitHub issue #${issue.number}.`;
-                console.log(reason);
-                throw new ApiError(reason, 500);
-            } else {
-                const reason = `Removed assignee from Linear ticket for GitHub issue #${issue.number}.`;
-                console.log(reason);
-                return reason;
+                if (!response?.success) {
+                    const reason = `Failed to remove assignee on Linear ticket for GitHub issue #${issue.number}.`;
+                    console.log(reason);
+                    throw new ApiError(reason, 500);
+                } else {
+                    const reason = `Removed assignee from Linear ticket for GitHub issue #${issue.number}.`;
+                    console.log(reason);
+                    return reason;
+                }
             }
         } else if (action === "assigned") {
             // Add assignee
 
-            const newAssignee = assignee?.id
+            const newAssignee = modifiedAssignee?.id
                 ? await prisma.user.findFirst({
-                      where: { githubUserId: assignee?.id },
+                      where: { githubUserId: modifiedAssignee?.id },
                       select: { linearUserId: true }
                   })
                 : null;
 
             if (!newAssignee) {
-                const reason = `Skipping assignee change for issue #${issue.number} as no Linear username was found for GitHub user ${assignee?.login}.`;
+                const reason = `Skipping assignee for issue #${issue.number} as no Linear user was found for GitHub user ${modifiedAssignee?.login}.`;
                 console.log(reason);
                 return reason;
             }
 
-            const response = await linear.issueUpdate(
-                syncedIssue.linearIssueId,
-                { assigneeId: newAssignee.linearUserId }
-            );
+            if (linearAssignee?.id != newAssignee?.linearUserId) {
+                const response = await linear.issueUpdate(
+                    syncedIssue.linearIssueId,
+                    { assigneeId: newAssignee.linearUserId }
+                );
 
-            if (!response?.success) {
-                const reason = `Failed to add assignee on Linear ticket for GitHub issue #${issue.number}.`;
-                console.log(reason);
-                throw new ApiError(reason, 500);
-            } else {
-                const reason = `Added assignee to Linear ticket for GitHub issue #${issue.number}.`;
-                console.log(reason);
-                return reason;
+                if (!response?.success) {
+                    const reason = `Failed to add assignee on Linear ticket for GitHub issue #${issue.number}.`;
+                    console.log(reason);
+                    throw new ApiError(reason, 500);
+                } else {
+                    const reason = `Added assignee to Linear ticket for GitHub issue #${issue.number}.`;
+                    console.log(reason);
+                    return reason;
+                }
             }
         }
     } else if (["milestoned", "demilestoned"].includes(action)) {

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -25,6 +25,7 @@ import { components } from "@octokit/openapi-types";
 import { linearQuery } from "../apollo";
 import { createMilestone, getGitHubFooter, setIssueMilestone } from "../github";
 import { ApiError, getIssueUpdateError } from "../errors";
+import { Issue, User } from "@octokit/webhooks-types";
 
 export async function linearWebhookHandler(
     body: LinearWebhookPayload,
@@ -659,13 +660,26 @@ export async function linearWebhookHandler(
 
         // Assignee change
         if ("assigneeId" in updatedFrom) {
-            const assigneeEndpoint = `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}/assignees`;
+            // Remove all assignees before re-assigning to avoid false re-assignment events
+            const issueEndpoint = `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}`;
 
-            // Assignee added
-            const assignee = data.assigneeId
+            const issueResponse = await got.get(issueEndpoint, {
+                headers: {
+                    Authorization: githubAuthHeader,
+                    "User-Agent": userAgentHeader
+                },
+                responseType: "json"
+            });
+
+            const prevAssignees = (
+                (await issueResponse.body) as Issue
+            ).assignees?.map((assignee: User) => assignee.login);
+
+            // Set new assignee
+            const newAssignee = data?.assigneeId
                 ? await prisma.user.findFirst({
                       where: {
-                          linearUserId: data.assigneeId
+                          linearUserId: data?.assigneeId
                       },
                       select: {
                           githubUsername: true
@@ -673,10 +687,15 @@ export async function linearWebhookHandler(
                   })
                 : null;
 
-            if (assignee) {
+            if (
+                prevAssignees.length > 0 &&
+                !prevAssignees.includes(newAssignee?.githubUsername)
+            ) {
+                const assigneeEndpoint = `${GITHUB.REPO_ENDPOINT}/${syncedIssue.GitHubRepo.repoName}/issues/${syncedIssue.githubIssueNumber}/assignees`;
+
                 const response = await got.post(assigneeEndpoint, {
                     json: {
-                        assignees: [assignee.githubUsername]
+                        assignees: [newAssignee?.githubUsername]
                     },
                     headers: {
                         Authorization: githubAuthHeader,
@@ -698,56 +717,36 @@ export async function linearWebhookHandler(
                         `Added assignee to GitHub issue #${syncedIssue.githubIssueNumber} for ${ticketName}.`
                     );
                 }
-            } else {
-                console.log(
-                    `Skipping assignee for ${ticketName} as no GitHub username was found for Linear user ${data.assigneeId}.`
-                );
-            }
 
-            // Remove previous assignee only if reassigned or deassigned explicitly
-            if (
-                updatedFrom.assigneeId !== null &&
-                (assignee || data.assigneeId === undefined)
-            ) {
-                const prevAssignee = await prisma.user.findFirst({
-                    where: {
-                        linearUserId: updatedFrom.assigneeId
+                // Remove old assignees on GitHub
+                const unassignResponse = await got.delete(assigneeEndpoint, {
+                    json: {
+                        assignees: [prevAssignees]
                     },
-                    select: {
-                        githubUsername: true
+                    headers: {
+                        Authorization: githubAuthHeader,
+                        "User-Agent": userAgentHeader
                     }
                 });
 
-                if (prevAssignee) {
-                    const response = await got.delete(assigneeEndpoint, {
-                        json: {
-                            assignees: [prevAssignee.githubUsername]
-                        },
-                        headers: {
-                            Authorization: githubAuthHeader,
-                            "User-Agent": userAgentHeader
-                        }
-                    });
-
-                    if (response.statusCode > 201) {
-                        console.log(
-                            getIssueUpdateError(
-                                "assignee",
-                                data,
-                                syncedIssue,
-                                response
-                            )
-                        );
-                    } else {
-                        console.log(
-                            `Removed assignee on GitHub issue #${syncedIssue.githubIssueNumber} for ${ticketName}.`
-                        );
-                    }
+                if (unassignResponse.statusCode > 201) {
+                    console.log(
+                        getIssueUpdateError(
+                            "assignee",
+                            data,
+                            syncedIssue,
+                            unassignResponse
+                        )
+                    );
                 } else {
                     console.log(
-                        `Skipping assignee removal for ${ticketName} as no GitHub username was found for Linear user ${updatedFrom.assigneeId}.`
+                        `Removed assignee from GitHub issue #${syncedIssue.githubIssueNumber} for ${ticketName}.`
                     );
                 }
+            } else {
+                console.log(
+                    `Skipping assignee for ${ticketName} as Linear user ${data.assigneeId} is already assigned.`
+                );
             }
         }
 


### PR DESCRIPTION
# Summary

- Prevent assignee sync if already synced
- Assign most-recently-added GH assignee to Linear
- Silently ignore assignment of unknown users

## Test Plan

- Open a new synced ticket
- Linear ✅ 
  - Assign: GH issue should have 1 assignee
  - Re-assign: GH issue should have 1 assignee
  - Un-assign: GH issue should have 0 assignees
  - Assign unknown user (not in DB): GH should show no change
- GitHub ✅ 
  - Assign: Linear ticket should have 1 assignee
  - Add assignee: Linear ticket should have the new assignee
  - Remove assignee: Linear ticket should be assigned to **1 of the remaining GH assignees**
  - Un-assign: Linear ticket should be un-assigned
  - Assign unknown user: Linear should show no change

## Related Issues

Closes #50 

