### PR TITLE
fix(multiple-labels): considering the case if user has added some other labels while creating an issue

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -117,4 +117,3 @@ export const GENERAL = {
         }
     ]
 };
-


### PR DESCRIPTION
# Summary

When creating an issue with `linear` label, we are considering other labels as well.

## Test Plan

How did you test your changes?

## Related Issues

Fix - #133 

