### PR TITLE
fix: github comment edit

### DIFF
--- a/pages/api/utils.ts
+++ b/pages/api/utils.ts
@@ -326,9 +326,9 @@ export const createLinearComment = async (
 export const updateLinearComment = async (
     linearCommentId: string,
     linear: LinearClient,
-    syncedIssue,
+    linearIssueId: string,
     modifiedComment: string,
-    issue
+    issueNumber: number
 ) => {
     const comment = await linear.commentUpdate(linearCommentId, {
         body: modifiedComment || ""
@@ -336,12 +336,12 @@ export const updateLinearComment = async (
 
     if (!comment.success) {
         throw new ApiError(
-            `Failed to Update comment on Linear issue ${syncedIssue.linearIssueId} for GitHub issue ${issue.number} of id ${linearCommentId}`,
+            `Failed to Update comment on Linear issue ${linearIssueId} for GitHub issue ${issueNumber} of id ${linearCommentId}`,
             500
         );
     } else {
         console.log(
-            `Update comment for GitHub issue #${issue.number} with Id ${linearCommentId}.`
+            `Update comment for GitHub issue #${issueNumber} with Id ${linearCommentId}.`
         );
     }
 };

--- a/pages/api/utils.ts
+++ b/pages/api/utils.ts
@@ -8,7 +8,11 @@ import {
     Platform
 } from "../../typings";
 import { GITHUB } from "../../utils/constants";
-import { replaceImgTags, replaceStrikethroughTags } from "../../utils";
+import {
+    replaceImgTags,
+    replaceStrikethroughTags,
+    replaceGithubComment
+} from "../../utils";
 import {
     Issue,
     IssueCommentCreatedEvent,
@@ -284,6 +288,7 @@ export const prepareMarkdownContent = async (
         let modifiedMarkdown = await replaceMentions(markdown, platform);
         modifiedMarkdown = await replaceStrikethroughTags(modifiedMarkdown);
         modifiedMarkdown = await replaceImgTags(modifiedMarkdown);
+        modifiedMarkdown = await replaceGithubComment(modifiedMarkdown);
 
         if (githubOptions?.anonymous && githubOptions?.sender) {
             return `>${modifiedMarkdown}\n\n—[${githubOptions.sender.login} on GitHub](${githubOptions.sender.html_url})`;
@@ -315,6 +320,29 @@ export const createLinearComment = async (
         );
     } else {
         console.log(`Created comment for GitHub issue #${issue.number}.`);
+    }
+};
+
+export const updateLinearComment = async (
+    linearCommentId: string,
+    linear: LinearClient,
+    syncedIssue,
+    modifiedComment: string,
+    issue
+) => {
+    const comment = await linear.commentUpdate(linearCommentId, {
+        body: modifiedComment || ""
+    });
+
+    if (!comment.success) {
+        throw new ApiError(
+            `Failed to Update comment on Linear issue ${syncedIssue.linearIssueId} for GitHub issue ${issue.number} of id ${linearCommentId}`,
+            500
+        );
+    } else {
+        console.log(
+            `Update comment for GitHub issue #${issue.number} with Id ${linearCommentId}.`
+        );
     }
 };
 

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -9,6 +9,16 @@ export const getGitHubFooter = (userName: string): string => {
     return `\n\n<!-- From ${sanitizedUsername} on Linear -->`;
 };
 
+export const getGithubFooterWithLinearCommentId = (
+    userName: string,
+    commentId: string
+): string => {
+    // To avoid exposing a user email if their username is an email address
+    const sanitizedUsername = userName.split("@")?.[0];
+
+    return `\n\n<!-- From ${sanitizedUsername} on Linear. LinearCommentId:${commentId}: -->`;
+};
+
 export const getGitHubTokenURL = (): string => {
     const scopes = GITHUB.SCOPES.join(",");
     const description = GITHUB.TOKEN_NOTE.split(" ").join("%20");

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -84,6 +84,12 @@ export const replaceStrikethroughTags = (text: string): string => {
     return text?.replace(/(?<!\\)~(?!~)/g, "~~") || text;
 };
 
+export const replaceGithubComment = (text: string): string => {
+    const regex = /<!--(.*?)-->/g;
+    const stringWithoutComments = text.replace(regex, "");
+    return stringWithoutComments;
+};
+
 export const getSyncFooter = (): string => {
     return `From [SyncLinear.com](https://synclinear.com)`;
 };

--- a/utils/webhook/github.handler.ts
+++ b/utils/webhook/github.handler.ts
@@ -33,7 +33,6 @@ import { LINEAR, SHARED } from "../constants";
 import got from "got";
 import { linearQuery } from "../apollo";
 import { ApiError } from "../errors";
-import { ActivityLogIcon } from "@radix-ui/react-icons";
 
 export async function githubWebhookHandler(
     body: IssuesEvent | IssueCommentCreatedEvent | MilestoneEvent,
@@ -186,9 +185,9 @@ export async function githubWebhookHandler(
             await updateLinearComment(
                 linearCommentId,
                 linear,
-                syncedIssue,
+                syncedIssue.linearIssueId,
                 modifiedComment,
-                issue
+                issue.number
             );
         }
     }

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -21,7 +21,12 @@ import got from "got";
 import { getLinearCycle, inviteMember } from "../linear";
 import { components } from "@octokit/openapi-types";
 import { linearQuery } from "../apollo";
-import { createMilestone, getGitHubFooter, setIssueMilestone } from "../github";
+import {
+    createMilestone,
+    getGitHubFooter,
+    getGithubFooterWithLinearCommentId,
+    setIssueMilestone
+} from "../github";
 import { ApiError, getIssueUpdateError } from "../errors";
 import { Issue, User } from "@octokit/webhooks-types";
 
@@ -41,6 +46,8 @@ export async function linearWebhookHandler(
         url,
         type: actionType
     }: LinearWebhookPayload = body;
+
+    console.log("BODY_LINEAR", body);
 
     const syncs = await prisma.sync.findMany({
         where: {
@@ -426,7 +433,10 @@ export async function linearWebhookHandler(
                     comment.body,
                     "linear"
                 );
-                const footer = getGitHubFooter(user.displayName);
+                const footer = getGithubFooterWithLinearCommentId(
+                    user.displayName,
+                    comment.id
+                );
 
                 const { error: commentError } = await createComment({
                     repoFullName,
@@ -935,7 +945,11 @@ export async function linearWebhookHandler(
             }
 
             const modifiedBody = await replaceMentions(data.body, "linear");
-            const footer = getGitHubFooter(data.user?.name);
+
+            const footer = getGithubFooterWithLinearCommentId(
+                data.user?.name,
+                data.id
+            );
 
             const { error: commentError } = await createComment({
                 repoFullName: syncedIssue.GitHubRepo.repoName,

--- a/utils/webhook/linear.handler.ts
+++ b/utils/webhook/linear.handler.ts
@@ -47,8 +47,6 @@ export async function linearWebhookHandler(
         type: actionType
     }: LinearWebhookPayload = body;
 
-    console.log("BODY_LINEAR", body);
-
     const syncs = await prisma.sync.findMany({
         where: {
             linearUserId: data.userId ?? data.creatorId


### PR DESCRIPTION
# Summary

Fixes: https://github.com/calcom/synclinear.com/issues/17

What does this PR do?
 If a comment is created using linear then if it is edited on github then the changes are also reflected on linear. 


One way we can get the ID of comment to be updated on linear is to store it in github Footer comment when it is created on linear.

<img width="837" alt="Screenshot 2023-10-12 at 2 12 51 AM" src="https://github.com/calcom/synclinear.com/assets/53316345/3546fcad-92ff-4464-96e0-6831497b50d1">


## Test Plan


https://github.com/calcom/synclinear.com/assets/53316345/90cfb1ef-61d2-4a92-aec4-ef2dc6d6a942




## Related Issues
https://github.com/calcom/synclinear.com/issues/17
Which issue does this PR resolve?

