### PR TITLE
[Feature] Change LINEAR_TICKET_ID_REGEX to support multiple lengths of identifiers

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -62,7 +62,7 @@ export const GENERAL = {
     CONTRIBUTE_URL: "https://github.com/calcom/synclinear.com",
     IMG_TAG_REGEX: /<img.*src=[\'|\"| ]?https?:\/\/(.*?)[\'|\"| ].*\/?>/g,
     INLINE_IMG_TAG_REGEX: /!\[.*?\]\((https:\/\/(?!.*\?signature=).*?)\)/g,
-    LINEAR_TICKET_ID_REGEX: /^\[\w{3}-\d{1,6}\]\s/,
+    LINEAR_TICKET_ID_REGEX: /^\[\w{1,5}-\d{1,6}\]\s/,
     LOGIN_KEY: "login",
     SYNCED_ITEMS: [
         {


### PR DESCRIPTION
# Summary

Update the `LINEAR_TICKET_ID_REGEX` to support Linear identifiers by 1 ~ 5 characters. 

## Test Plan

- Set up Linear team identifier manually with not only three characters.
  ![CleanShot 2024-02-29 at 12 02 23](https://github.com/calcom/synclinear.com/assets/959606/df494f33-fa50-468a-8203-56d8edefa312)

- Create a story on the Linear team with a `Public` label and let it sync to the GitHub repo.
- The newly created GitHub issue should not trigger to create a duplicated Linear story.

## Related Issues
#156 

