### PR TITLE
chore: display repo name in linear issue link

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -121,7 +121,7 @@ export const getAttachmentQuery = (
     return `mutation {
         attachmentCreate(input: {
             issueId: "${issueId}"
-            title: "GitHub Issue #${issueNumber}"
+            title: "GitHub Issue #${issueNumber} - ${repoFullName}"
             subtitle: "Synchronized"
             url: "https://github.com/${repoFullName}/issues/${issueNumber}"
             iconUrl: "${GITHUB.ICON_URL}"


### PR DESCRIPTION
I have multiple repositories connected and I can't tell which link it's meant for unless I click on the link and open it a new tab. 

It'd be great if I can see the repo name from out side the link banner like this 👇

![image](https://github.com/calcom/synclinear.com/assets/97709651/3c3501c9-efe4-4220-8785-3d2bdc8537db)
