### PR TITLE
fix/165-Github logo centered in the footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -4,7 +4,7 @@ import GitHubLogo from "./icons/GitHubLogo";
 const Footer = () => {
     return (
         <footer className="w-full p-6 text-lg font-light text-gray-200">
-            <div className="p-20 flex flex-col sm:flex-row items-center justify-between gap-4 bg-gray-900 rounded-3xl">
+            <div className="p-20 flex flex-col items-center justify-between gap-4 bg-gray-900 rounded-3xl">
                 <div className="space-x-1 text-center">
                     <span>An open-source project by</span>
                     <a
@@ -17,16 +17,17 @@ const Footer = () => {
                         Cal.com
                     </a>
                 </div>
-                <div></div>
-                <a
-                    href="https://github.com/calcom/synclinear.com"
-                    rel="noreferrer"
-                    target="_blank"
-                    className="text-gray-400 hover:text-gray-100 sm:order-first"
-                    aria-label="Visit codebase"
-                >
-                    <GitHubLogo />
-                </a>
+                <div>
+                    <a
+                        href="https://github.com/calcom/synclinear.com"
+                        rel="noreferrer"
+                        target="_blank"
+                        className="text-gray-400 hover:text-gray-100 sm:order-first"
+                        aria-label="Visit codebase"
+                    >
+                        <GitHubLogo />
+                    </a>
+                </div>
             </div>
         </footer>
     );


### PR DESCRIPTION
# Summary

Centered the Github Logo in the footer to enhance the UI

<img width="913" alt="image" src="https://github.com/user-attachments/assets/d74e7c52-d093-4727-8be7-0975606fd610">


## Related Issues
fixes #165 

