### PR TITLE
Add required linear 'admin' scope

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,7 +8,7 @@ export const LINEAR = {
     OAUTH_ID: process.env.NEXT_PUBLIC_LINEAR_OAUTH_ID,
     OAUTH_URL: "https://linear.app/oauth/authorize",
     TOKEN_URL: "https://api.linear.app/oauth/token",
-    SCOPES: ["write"],
+    SCOPES: ["admin","write"],
     NEW_TOKEN_URL: "https://linear.app/settings/api",
     TOKEN_SECTION_HEADER: "Personal API keys",
     GRAPHQL_ENDPOINT: "https://api.linear.app/graphql",


### PR DESCRIPTION
Fixes #171

Linear changed and now you need admin scope to deploy webhooks: https://linear.app/developers/webhooks
_("Only workspace admins, or OAuth applications with the admin scope, can create or read webhooks.")_

<img width="411" alt="image" src="https://github.com/user-attachments/assets/397edd8e-de55-491c-985b-9940752a0f72" />
